### PR TITLE
feat: redesign home view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # agsMaranatha
 Nuevo dominio del colegio Maranatha Aguascalientes
+
+## Public Font Library Recommendation
+
+To complement the refreshed header design, consider using **Google Fonts**, a free and widely trusted font library. It offers an extensive catalog of open-licensed typefaces, easy CDN integration, and performance-focused loading options (such as `display=swap`). Visit [fonts.google.com](https://fonts.google.com) to browse families, generate `<link>` tags, or download font files for self-hosting.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2Pk6dp9JdR2LrjHkG4BfXoJ1cQW+X4V9Z4O0j3x0WkNsMZ8zKeqf3r9F0w=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <title>Escuela Primaria Ejemplo</title>
   </head>
   <body>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,18 +1,223 @@
 <template>
-  <footer>
-    <div>
-      &copy; {{ new Date().getFullYear() }} Escuela Primaria Ejemplo
-      <span style="margin-left:10px;">| Tel: (XXX) 123-4567 | Dirección: Calle Ejemplo #123</span>
+  <footer class="footer">
+    <div class="footer__content">
+      <section class="footer__section footer__section--brand" aria-labelledby="footer-location">
+        <div class="footer__crown" aria-hidden="true">
+          <i class="fa-solid fa-crown"></i>
+        </div>
+        <h2 id="footer-location" class="footer__heading">Ubicación</h2>
+        <address class="footer__text">
+          David Alfaro Siqueiros, N° 401<br />
+          Fraccionamiento Lomas de Santa Anita, 20164<br />
+          Aguascalientes, Ags.
+        </address>
+      </section>
+
+      <section class="footer__section" aria-labelledby="footer-contact">
+        <h2 id="footer-contact" class="footer__heading">Contacto</h2>
+        <ul class="footer__list">
+          <li class="footer__item">
+            <i class="fa-solid fa-phone"></i>
+            <a href="tel:4491466009">449 146 6009</a>
+          </li>
+          <li class="footer__item">
+            <i class="fa-solid fa-envelope"></i>
+            <a href="mailto:colegiomaranathaags@hotmail.com">colegiomaranathaags@hotmail.com</a>
+          </li>
+        </ul>
+      </section>
+
+      <section class="footer__section" aria-labelledby="footer-social">
+        <h2 id="footer-social" class="footer__heading">Síguenos en:</h2>
+        <div class="footer__social">
+          <a
+            class="footer__social-link"
+            href="https://www.facebook.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <i class="fa-brands fa-facebook-f"></i>
+          </a>
+          <a
+            class="footer__social-link"
+            href="https://www.instagram.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <i class="fa-brands fa-instagram"></i>
+          </a>
+          <a
+            class="footer__social-link"
+            href="https://www.youtube.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="YouTube"
+          >
+            <i class="fa-brands fa-youtube"></i>
+          </a>
+        </div>
+      </section>
+    </div>
+
+    <div class="footer__bottom">
+      Derechos Reservados © Colegio Maranatha Aguascalientes {{ currentYear }}
     </div>
   </footer>
 </template>
 
+<script>
+export default {
+  name: "FooterSection",
+  data() {
+    return {
+      currentYear: new Date().getFullYear(),
+    };
+  },
+};
+</script>
+
 <style scoped>
-footer {
-  background: #2c3e50;
-  color: #fff;
+.footer {
+  background: linear-gradient(135deg, #1d3ba8 0%, #233d8d 50%, #1d3ba8 100%);
+  color: #f3f5ff;
+  font-family: "Montserrat", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", sans-serif;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.footer__content {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2.5rem;
+  padding: 3rem clamp(1.5rem, 5vw, 4rem);
+  align-items: start;
+}
+
+.footer__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer__section--brand {
+  position: relative;
+  padding-top: 0.5rem;
+}
+
+.footer__crown {
+  font-size: clamp(2.75rem, 6vw, 3.5rem);
+  color: #ffcf4a;
+  margin-bottom: 0.5rem;
+}
+
+.footer__heading {
+  font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.footer__text {
+  font-style: normal;
+  line-height: 1.6;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+}
+
+.footer__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.footer__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+}
+
+.footer__item i {
+  font-size: 1.1rem;
+  color: #ffcf4a;
+}
+
+.footer__item a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer__item a:hover,
+.footer__item a:focus {
+  color: #ffcf4a;
+}
+
+.footer__social {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.footer__social-link {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #f3f5ff;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.footer__social-link:hover,
+.footer__social-link:focus {
+  background-color: rgba(255, 207, 74, 0.2);
+  color: #ffcf4a;
+  transform: translateY(-2px);
+}
+
+.footer__bottom {
   text-align: center;
-  padding: 1rem 0;
-  font-size: 1rem;
+  padding: 1rem clamp(1.5rem, 5vw, 3rem) 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 900px) {
+  .footer__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem;
+  }
+
+  .footer__section--brand {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 600px) {
+  .footer__content {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .footer__section {
+    align-items: center;
+  }
+
+  .footer__item,
+  .footer__social {
+    justify-content: center;
+  }
+
+  .footer__crown {
+    margin-bottom: 0.25rem;
+  }
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,51 +1,271 @@
 <script setup>
+import { ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import LogoHeader from '../assets/LogoHeader.png'
+
+const links = [
+  { to: '/', label: 'Home' },
+  { to: '/nosotros', label: 'Nosotros' },
+  { to: '/oferta-educativa', label: 'Oferta Educativa' },
+  { to: '/eventos-especiales', label: 'Eventos Especiales' },
+  { to: '/contacto', label: 'Contacto' },
+]
+
+const isMenuOpen = ref(false)
+const route = useRoute()
+
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value
+}
+
+watch(
+  () => route.fullPath,
+  () => {
+    isMenuOpen.value = false
+  }
+)
 </script>
 
 <template>
-  <header>
-    <nav>
-      <img :src="LogoHeader" alt="Logo" height="55" />
-      <ul>
-        <li><router-link to="/">Home</router-link></li>
-        <li><router-link to="/nosotros">Nosotros</router-link></li>
-        <li><router-link to="/contacto">Contacto</router-link></li>
-        <li><router-link to="/oferta-educativa">Oferta Educativa</router-link></li>
-        <li><router-link to="/eventos-especiales">Eventos Especiales</router-link></li>
+  <header class="site-header">
+    <nav class="nav">
+      <RouterLink to="/" class="brand" aria-label="Colegio Maranatha home">
+        <img :src="LogoHeader" alt="Colegio Maranatha" />
+      </RouterLink>
+
+      <button
+        :class="['menu-toggle', { active: isMenuOpen }]"
+        type="button"
+        @click="toggleMenu"
+        :aria-expanded="isMenuOpen ? 'true' : 'false'"
+        aria-controls="main-navigation"
+      >
+        <span class="menu-toggle__label">Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+
+      <ul :class="['nav-links', { open: isMenuOpen }]" id="main-navigation">
+        <li v-for="link in links" :key="link.to" class="nav-item">
+          <RouterLink :to="link.to" custom>
+            <template #default="{ href, navigate, isExactActive }">
+              <a
+                :href="href"
+                @click="navigate"
+                :class="['nav-link', { active: isExactActive }]"
+              >
+                {{ link.label }}
+              </a>
+            </template>
+          </RouterLink>
+        </li>
       </ul>
     </nav>
   </header>
 </template>
 
 <style scoped>
-header {
-  background: #2c3e50;
-  color: #fff;
-  padding: 1rem 0;
+.site-header {
+  background: linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%);
+  box-shadow: 0 4px 15px rgba(13, 71, 161, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
-nav {
+
+.nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 1000px;
+  max-width: 1200px;
+  padding: 1.25rem 1.5rem;
   margin: 0 auto;
+  gap: 2rem;
 }
-ul {
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+}
+
+.brand img {
+  max-width: min(290px, 60vw);
+  height: auto;
+}
+
+.menu-toggle {
+  align-items: center;
+  background: transparent;
+  border: 2px solid #153d8a;
+  border-radius: 999px;
+  color: #153d8a;
+  cursor: pointer;
+  display: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  gap: 0.75rem;
+  letter-spacing: 0.08em;
+  padding: 0.55rem 1rem;
+  text-transform: uppercase;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  background: #153d8a;
+  color: #ffffff;
+}
+
+.menu-toggle__label {
+  display: inline-flex;
+}
+
+.menu-toggle__icon {
+  position: relative;
+  width: 18px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.menu-toggle__icon::before,
+.menu-toggle__icon::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 18px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transition: transform 0.3s ease, top 0.3s ease, opacity 0.3s ease;
+}
+
+.menu-toggle__icon::before {
+  top: -6px;
+}
+
+.menu-toggle__icon::after {
+  top: 6px;
+}
+
+.menu-toggle.active .menu-toggle__icon {
+  background: transparent;
+}
+
+.menu-toggle.active .menu-toggle__icon::before {
+  top: 0;
+  transform: rotate(45deg);
+}
+
+.menu-toggle.active .menu-toggle__icon::after {
+  top: 0;
+  transform: rotate(-45deg);
+}
+
+.nav-links {
   list-style: none;
   display: flex;
-  gap: 1.2rem;
+  align-items: center;
+  gap: 1.75rem;
   margin: 0;
   padding: 0;
 }
-li {
-  font-size: 1.1rem;
+
+.nav-item {
+  position: relative;
 }
-a {
-  color: #fff;
+
+.nav-link {
+  color: #153d8a;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-decoration: none;
+  text-transform: uppercase;
+  position: relative;
+  padding-bottom: 0.35rem;
+  transition: color 0.3s ease;
 }
-a.router-link-exact-active {
-  font-weight: bold;
-  text-decoration: underline;
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 3px;
+  background: #c62828;
+  border-radius: 2px;
+  transition: width 0.3s ease, left 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: #c62828;
+}
+
+.nav-link:hover::after,
+.nav-link:focus-visible::after {
+  width: 100%;
+  left: 0;
+}
+
+.nav-link.active {
+  color: #c62828;
+}
+
+.nav-link.active::after {
+  width: 60%;
+  left: 20%;
+}
+
+@media (max-width: 1024px) {
+  .nav {
+    padding: 1rem;
+  }
+
+  .nav-links {
+    gap: 1.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav {
+    flex-wrap: wrap;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    flex-basis: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 20px 45px rgba(13, 71, 161, 0.15);
+    margin-top: 1rem;
+    padding: 1.25rem 1.5rem;
+    position: relative;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .nav-links.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .nav-link {
+    font-size: 0.9rem;
+  }
+
+  .nav-link.active::after {
+    left: 0;
+    width: 80px;
+  }
 }
 </style>

--- a/src/views/Contacto.vue
+++ b/src/views/Contacto.vue
@@ -1,14 +1,277 @@
 <template>
-  <section>
-    <h2>Contacto</h2>
-    <p>
-      Escríbenos para más información.
-    </p>
-    <ul>
-      <li>Email: contacto@escuelaejemplo.edu.mx</li>
-      <li>Teléfono: (XXX) 123-4567</li>
-      <li>Dirección: Calle Ejemplo #123, Colonia Centro</li>
-    </ul>
-    <img src="https://images.pexels.com/photos/207691/pexels-photo-207691.jpeg?auto=compress&w=600" alt="Contacto" style="width:100%;max-width:400px;" />
+  <section class="contact-page">
+    <div class="contact-card">
+      <button class="contact-close" type="button" aria-label="Cerrar formulario">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+      <header class="contact-header">
+        <h2 class="contact-title">¿Requiere más información?</h2>
+        <p class="contact-subtitle">
+          Escríbanos y nos pondremos en contacto con usted a la brevedad posible.
+        </p>
+      </header>
+      <form class="contact-form" @submit.prevent="handleSubmit">
+        <div class="contact-grid">
+          <div class="contact-field">
+            <label class="contact-label" for="contact-name">Nombre:</label>
+            <input
+              id="contact-name"
+              v-model="form.name"
+              type="text"
+              required
+              autocomplete="name"
+              placeholder="Nombre completo"
+              class="contact-input"
+            />
+          </div>
+          <div class="contact-field">
+            <label class="contact-label" for="contact-email">Correo:</label>
+            <input
+              id="contact-email"
+              v-model="form.email"
+              type="email"
+              required
+              autocomplete="email"
+              placeholder="Correo electrónico"
+              class="contact-input"
+            />
+          </div>
+          <div class="contact-field">
+            <label class="contact-label" for="contact-phone">Teléfono:</label>
+            <input
+              id="contact-phone"
+              v-model="form.phone"
+              type="tel"
+              required
+              inputmode="tel"
+              pattern="\\d{10}"
+              autocomplete="tel"
+              placeholder="Teléfono a 10 dígitos"
+              class="contact-input"
+            />
+          </div>
+          <div class="contact-field contact-message">
+            <label class="contact-label" for="contact-message">Ingrese su mensaje:</label>
+            <textarea
+              id="contact-message"
+              v-model="form.message"
+              required
+              rows="6"
+              placeholder="Escriba los detalles de su consulta"
+              class="contact-input contact-textarea"
+            ></textarea>
+          </div>
+        </div>
+        <div class="contact-actions">
+          <button class="contact-submit" type="submit">Enviar mensaje</button>
+        </div>
+      </form>
+    </div>
   </section>
 </template>
+
+<script setup>
+import { reactive } from 'vue'
+
+const RECIPIENT_EMAIL = 'contacto@agsmaranatha.edu.mx'
+
+const form = reactive({
+  name: '',
+  email: '',
+  phone: '',
+  message: '',
+})
+
+const handleSubmit = () => {
+  const subject = encodeURIComponent('Solicitud de información')
+  const bodyLines = [
+    `Nombre: ${form.name}`,
+    `Correo: ${form.email}`,
+    `Teléfono: ${form.phone}`,
+    '',
+    form.message,
+  ]
+  const body = encodeURIComponent(bodyLines.join('\n'))
+  window.location.href = `mailto:${RECIPIENT_EMAIL}?subject=${subject}&body=${body}`
+}
+</script>
+
+<style scoped>
+.contact-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 220px);
+  padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 3vw, 3rem);
+  background: linear-gradient(180deg, #f8f8f8 0%, #f1f1f1 100%);
+}
+
+.contact-card {
+  position: relative;
+  width: min(960px, 100%);
+  background: #ffffff;
+  border-radius: 18px;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  border: 1px solid #f0f0f0;
+}
+
+.contact-close {
+  position: absolute;
+  top: clamp(0.75rem, 2vw, 1.5rem);
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  border: none;
+  background: transparent;
+  color: #da1a32;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.contact-close:focus-visible {
+  outline: 3px solid rgba(218, 26, 50, 0.35);
+  outline-offset: 4px;
+}
+
+.contact-close:hover {
+  transform: scale(1.05);
+  opacity: 0.8;
+}
+
+.contact-header {
+  text-align: center;
+  margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.contact-title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.6rem, 3.2vw, 2.25rem);
+  font-weight: 700;
+  color: #333333;
+}
+
+.contact-subtitle {
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.125rem);
+  color: #6b6b6b;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.contact-grid {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.contact-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #444444;
+}
+
+.contact-input {
+  padding: 0.85rem 1rem;
+  border: 2px solid #da1a32;
+  border-radius: 12px;
+  font-size: 1rem;
+  color: #2c2c2c;
+  background-color: #fff;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.contact-input::placeholder {
+  color: #da1a32;
+  opacity: 0.65;
+}
+
+.contact-input:focus {
+  outline: none;
+  border-color: #b81327;
+  box-shadow: 0 0 0 3px rgba(218, 26, 50, 0.15);
+}
+
+.contact-textarea {
+  resize: vertical;
+  min-height: 180px;
+}
+
+.contact-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.contact-submit {
+  padding: 0.85rem 2.75rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #da1a32 0%, #f04d4f 100%);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(218, 26, 50, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-submit:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(218, 26, 50, 0.3);
+}
+
+.contact-submit:focus-visible {
+  outline: 3px solid rgba(218, 26, 50, 0.35);
+  outline-offset: 4px;
+}
+
+@media (min-width: 768px) {
+  .contact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .contact-message {
+    grid-column: span 2;
+  }
+}
+
+@media (min-width: 960px) {
+  .contact-grid {
+    grid-template-columns: 320px 1fr;
+    align-items: start;
+  }
+
+  .contact-field:nth-child(-n + 3) {
+    grid-column: 1 / 2;
+  }
+
+  .contact-message {
+    grid-column: 2 / 3;
+    grid-row: 1 / span 3;
+    height: 100%;
+  }
+
+  .contact-textarea {
+    height: 100%;
+    min-height: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .contact-close {
+    font-size: 1.35rem;
+  }
+
+  .contact-submit {
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,87 +1,933 @@
 <template>
-  <section>
-    <!-- Hero Image -->
-    <div class="hero">
-      <img src="https://images.unsplash.com/photo-1503676382389-4809596d5290?auto=format&fit=crop&w=1200&q=80" alt="Hero Escuela" />
-      <div class="hero-text">
-        <h1>Bienvenidos a la Escuela Primaria Ejemplo</h1>
-        <p>
-          Nuestra escuela ofrece un ambiente seguro y estimulante para el aprendizaje de los niños.
+  <main class="home-page">
+    <section class="hero-section">
+      <img
+        class="hero-background"
+        src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1800&q=80"
+        alt="Equipo docente del Colegio Maranatha"
+      />
+      <div class="hero-overlay">
+        <p class="hero-eyebrow">Bienvenidos al Colegio Maranatha</p>
+        <h1>Caminando en la Visión del Señor</h1>
+        <p class="hero-subcopy">
+          Acompañamos cada etapa educativa con fe, excelencia académica y cuidado integral para
+          nuestras familias.
         </p>
       </div>
-    </div>
+      <div class="levels-grid">
+        <article
+          v-for="level in levels"
+          :key="level.name"
+          class="level-card"
+          :style="`--level-color: ${level.color}`"
+          tabindex="0"
+        >
+          <div class="card-face card-face--front">
+            <h3>{{ level.name }}</h3>
+          </div>
+          <div class="card-face card-face--back">
+            <h4>{{ level.name }}</h4>
+            <p>{{ level.description }}</p>
+          </div>
+        </article>
+      </div>
+    </section>
 
-    <!-- Carousel -->
-    <div class="carousel">
-      <button @click="prev">&#8592;</button>
-      <img :src="images[current]" :alt="'Imagen '+(current+1)" />
-      <button @click="next">&#8594;</button>
-    </div>
-  </section>
+    <section class="offer-highlight">
+      <div class="offer-text">
+        <h2>Oferta Educativa</h2>
+        <p>
+          Buscamos constantemente que nuestros estudiantes identifiquen sus habilidades y capacidades
+          para que las desarrollen en plenitud. De esta manera, ellos se hacen conscientes de su
+          potencial y saben que está en ellos comprometerse para mejorar no sólo su vida, sino su
+          entorno.
+        </p>
+      </div>
+      <div class="offer-pillars">
+        <div v-for="pillar in pillars" :key="pillar.title" class="pillar">
+          <div class="pillar-icon">
+            <i :class="pillar.icon" aria-hidden="true"></i>
+          </div>
+          <h3>{{ pillar.title }}</h3>
+          <p>{{ pillar.copy }}</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="gallery-section" aria-label="Recorrido fotográfico">
+      <div class="carousel">
+        <button class="carousel-control" type="button" @click="prevSlide" aria-label="Anterior">
+          <i class="fas fa-chevron-left" aria-hidden="true"></i>
+        </button>
+        <div class="carousel-window">
+          <div class="carousel-track">
+            <figure
+              v-for="image in visibleImages"
+              :key="image.src"
+              class="carousel-item"
+            >
+              <img :src="image.src" :alt="image.alt" loading="lazy" />
+            </figure>
+          </div>
+        </div>
+        <button class="carousel-control" type="button" @click="nextSlide" aria-label="Siguiente">
+          <i class="fas fa-chevron-right" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="carousel-dots" role="tablist" aria-label="Seleccionar grupo de imágenes">
+        <button
+          v-for="index in totalSlides"
+          :key="index"
+          :class="['dot', { active: currentSlide === index - 1 }]"
+          type="button"
+          role="tab"
+          :aria-selected="currentSlide === index - 1"
+          @click="goToSlide(index - 1)"
+        >
+          <span class="sr-only">Ver imágenes {{ index }}</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="team-section" aria-labelledby="team-title">
+      <div class="team-header">
+        <h2 id="team-title">Conoce a nuestro personal administrativo.</h2>
+        <p>
+          Nuestro liderazgo acompaña a cada familia con vocación, profesionalismo y un compromiso
+          genuino por el crecimiento académico y espiritual de cada estudiante.
+        </p>
+      </div>
+      <div class="team-grid">
+        <article v-for="member in leadership" :key="member.name" class="team-card">
+          <div class="team-avatar">
+            <img :src="member.image" :alt="`Fotografía de ${member.name}`" loading="lazy" />
+          </div>
+          <h3>{{ member.name }}</h3>
+          <p class="team-role">{{ member.role }}</p>
+        </article>
+      </div>
+      <button class="team-button" type="button" @click="openModal">Conoce al equipo de maestros</button>
+    </section>
+
+    <transition name="modal-fade">
+      <div
+        v-if="showModal"
+        class="modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="team-modal-title"
+        @click.self="closeModal"
+      >
+        <div class="modal-panel">
+          <header class="modal-header">
+            <h3 id="team-modal-title">Equipo docente completo</h3>
+            <button type="button" class="modal-close" @click="closeModal" aria-label="Cerrar">
+              <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+          </header>
+          <div class="modal-content">
+            <p>
+              Cada maestro aporta su experiencia y carisma para guiar el aprendizaje diario de nuestros
+              alumnos.
+            </p>
+            <div class="modal-grid">
+              <article v-for="member in completeTeam" :key="member.name" class="team-card">
+                <div class="team-avatar">
+                  <img :src="member.image" :alt="`Fotografía de ${member.name}`" loading="lazy" />
+                </div>
+                <h4>{{ member.name }}</h4>
+                <p class="team-role">{{ member.role }}</p>
+              </article>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="team-button" @click="closeModal">Cerrar</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </main>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
-const images = [
-  "https://images.pexels.com/photos/256401/pexels-photo-256401.jpeg?auto=compress&w=600",
-  "https://images.unsplash.com/photo-1464983953574-0892a716854b?auto=format&fit=crop&w=600&q=80",
-  "https://images.pexels.com/photos/207691/pexels-photo-207691.jpeg?auto=compress&w=600",
-  "https://images.unsplash.com/photo-1512139219482-b7f4a2f26c1a?auto=format&fit=crop&w=600&q=80"
+const levels = [
+  {
+    name: 'Preescolar',
+    color: '#8CA6DB',
+    description: 'Edades 3 a 5. Desarrollamos habilidades socioemocionales, psicomotoras y el amor por el aprendizaje a través del juego guiado.'
+  },
+  {
+    name: 'Primaria',
+    color: '#6F8DD9',
+    description: 'Edades 6 a 11. Fortalecemos pensamiento crítico, comprensión lectora y bases académicas con valores cristianos.'
+  },
+  {
+    name: 'Secundaria',
+    color: '#4C6BC7',
+    description: 'Edades 12 a 14. Acompañamos el desarrollo de identidad, liderazgo y trabajo colaborativo con proyectos interdisciplinarios.'
+  },
+  {
+    name: 'Preparatoria',
+    color: '#1E2A78',
+    description: 'Edades 15 a 18. Preparamos para la universidad con orientación vocacional, dominio tecnológico y formación espiritual.'
+  }
 ]
-const current = ref(0)
-const next = () => {
-  current.value = (current.value + 1) % images.length
+
+const pillars = [
+  {
+    title: 'Inspiramos creatividad',
+    copy: 'Integramos arte, música y experiencias vivenciales para despertar la imaginación en cada aula.',
+    icon: 'fas fa-lightbulb'
+  },
+  {
+    title: 'Excelencia académica',
+    copy: 'Programas actualizados y docentes certificados garantizan un aprendizaje significativo.',
+    icon: 'fas fa-graduation-cap'
+  },
+  {
+    title: 'Cuidado integral',
+    copy: 'Acompañamos el bienestar físico, emocional y espiritual de nuestra comunidad educativa.',
+    icon: 'fas fa-hands-holding-heart'
+  }
+]
+
+const carouselImages = [
+  {
+    src: 'https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=900&q=80',
+    alt: 'Alumno trabajando en su cuaderno'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=900&q=80',
+    alt: 'Estudiante participando en clase'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1602016753527-319f3c4c41c4?auto=format&fit=crop&w=900&q=80',
+    alt: 'Alumno utilizando tablet en clase'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1524178232363-1fb2b075b655?auto=format&fit=crop&w=900&q=80',
+    alt: 'Docente guiando actividad artística'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1509062522246-3755977927d7?auto=format&fit=crop&w=900&q=80',
+    alt: 'Niños trabajando en equipo'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=900&q=80',
+    alt: 'Equipo deportivo escolar entrenando'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1546456073-6712f79251bb?auto=format&fit=crop&w=900&q=80',
+    alt: 'Docente impartiendo clase de ciencias'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1488190211105-8b0e65b80b4e?auto=format&fit=crop&w=900&q=80',
+    alt: 'Materiales escolares sobre escritorio'
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1516979187457-637abb4f9353?auto=format&fit=crop&w=900&q=80',
+    alt: 'Estudiantes colaborando en clase'
+  }
+]
+
+const leadership = [
+  {
+    name: 'Pastor Enrique Clavellinas',
+    role: 'Director',
+    image: 'https://images.unsplash.com/photo-1603415526960-f7e0328c63b1?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Pastora Ana Luisa Clavellinas',
+    role: 'Directora',
+    image: 'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Patricia Zuno',
+    role: 'Subdirectora',
+    image: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80'
+  }
+]
+
+const extendedTeam = [
+  {
+    name: 'Juan Carlos Herrera',
+    role: 'Coordinador Académico',
+    image: 'https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'María Fernanda Ortiz',
+    role: 'Orientadora Educativa',
+    image: 'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Rafael Ramírez',
+    role: 'Profesor de Matemáticas',
+    image: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Daniela Márquez',
+    role: 'Profesora de Ciencias',
+    image: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Luis Alberto Pérez',
+    role: 'Profesor de Historia',
+    image: 'https://images.unsplash.com/photo-1546456073-6712f79251bb?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Cecilia Jiménez',
+    role: 'Coordinadora de Inglés',
+    image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Jorge Martínez',
+    role: 'Profesor de Música',
+    image: 'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Verónica Salas',
+    role: 'Profesora de Artes',
+    image: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Carlos Guzmán',
+    role: 'Entrenador Deportivo',
+    image: 'https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Ariadna Torres',
+    role: 'Psicóloga Escolar',
+    image: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Miguel Ángel Lira',
+    role: 'Profesor de Tecnología',
+    image: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=400&q=80'
+  },
+  {
+    name: 'Sofía Maldonado',
+    role: 'Profesora de Literatura',
+    image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=400&q=80'
+  }
+]
+
+const completeTeam = computed(() => [...leadership, ...extendedTeam])
+
+const currentSlide = ref(0)
+const itemsPerSlide = 3
+const totalSlides = computed(() => Math.ceil(carouselImages.length / itemsPerSlide))
+
+const goToSlide = (index) => {
+  const clampedIndex = Math.min(Math.max(index, 0), totalSlides.value - 1)
+  currentSlide.value = clampedIndex
 }
-const prev = () => {
-  current.value = (current.value - 1 + images.length) % images.length
+
+const nextSlide = () => {
+  currentSlide.value = (currentSlide.value + 1) % totalSlides.value
 }
+
+const prevSlide = () => {
+  currentSlide.value = (currentSlide.value - 1 + totalSlides.value) % totalSlides.value
+}
+
+const visibleImages = computed(() => {
+  const start = currentSlide.value * itemsPerSlide
+  return carouselImages.slice(start, start + itemsPerSlide)
+})
+
+const showModal = ref(false)
+
+const openModal = () => {
+  showModal.value = true
+  document.body.style.overflow = 'hidden'
+}
+
+const closeModal = () => {
+  showModal.value = false
+  document.body.style.overflow = ''
+}
+
+const handleEsc = (event) => {
+  if (event.key === 'Escape') {
+    closeModal()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleEsc)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleEsc)
+  document.body.style.overflow = ''
+})
 </script>
 
 <style scoped>
-.hero {
-  position: relative;
-  width: 100%;
-  max-height: 350px;
-  overflow: hidden;
+.home-page {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  padding-bottom: 4rem;
+  background: #f5f5f7;
+  color: #1a1a1a;
 }
-.hero img {
+
+.hero-section {
+  position: relative;
+  min-height: 540px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+  border-bottom-left-radius: 2rem;
+  border-bottom-right-radius: 2rem;
+  background: linear-gradient(180deg, rgba(10, 28, 66, 0.3), rgba(10, 28, 66, 0.7));
+}
+
+.hero-background {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: 350px;
+  height: 100%;
   object-fit: cover;
   filter: brightness(0.7);
 }
-.hero-text {
+
+.hero-overlay {
   position: absolute;
-  top: 30%;
-  left: 10%;
-  color: white;
-  background: rgba(44,62,80,0.6);
-  padding: 1rem 2rem;
-  border-radius: 8px;
+  top: 12%;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  color: #ffffff;
+  max-width: 900px;
+  padding: 1.5rem 2rem;
+  backdrop-filter: blur(2px);
 }
+
+.hero-eyebrow {
+  font-size: 1.125rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.hero-section h1 {
+  font-size: clamp(2.5rem, 3vw + 1.5rem, 3.5rem);
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+}
+
+.hero-subcopy {
+  font-size: 1.1rem;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.levels-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  padding: 2.5rem clamp(1.25rem, 4vw, 3rem) 3rem;
+  width: 100%;
+  max-width: 1080px;
+}
+
+.level-card {
+  position: relative;
+  background: var(--level-color);
+  color: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2.5rem 1rem;
+  text-align: center;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  outline: none;
+}
+
+.level-card:focus-visible {
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.8);
+  transform: translateY(-6px);
+}
+
+.level-card:hover,
+.level-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 45px rgba(12, 31, 71, 0.25);
+}
+
+.card-face {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  height: 100%;
+  transition: opacity 0.3s ease;
+}
+
+.card-face--back {
+  position: absolute;
+  inset: 0;
+  padding: 2.5rem 1.5rem;
+  background: rgba(8, 20, 58, 0.88);
+  opacity: 0;
+}
+
+.level-card:hover .card-face--back,
+.level-card:focus-visible .card-face--back {
+  opacity: 1;
+}
+
+.level-card:hover .card-face--front,
+.level-card:focus-visible .card-face--front {
+  opacity: 0;
+}
+
+.card-face h3,
+.card-face h4 {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.45rem;
+}
+
+.card-face p {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.offer-highlight {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 2rem;
+  padding: 0 clamp(1.5rem, 5vw, 5rem);
+}
+
+.offer-text h2 {
+  font-size: clamp(2rem, 1.5vw + 1.5rem, 2.8rem);
+  margin-bottom: 1rem;
+  color: #b8860b;
+}
+
+.offer-text p {
+  max-width: 840px;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #3a3a3a;
+}
+
+.offer-pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.pillar {
+  background: #ffffff;
+  padding: 2rem 1.75rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.pillar:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.12);
+}
+
+.pillar-icon {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f5d267, #d4a017);
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  font-size: 2rem;
+}
+
+.pillar h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.pillar p {
+  margin: 0;
+  color: #4a4a4a;
+  line-height: 1.6;
+}
+
+.gallery-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 clamp(1.25rem, 6vw, 6rem);
+}
+
 .carousel {
   display: flex;
   align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 1100px;
+}
+
+.carousel-window {
+  overflow: hidden;
+  border-radius: 1.5rem;
+  flex: 1;
+}
+
+
+.carousel-track {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.carousel-item {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 1.25rem;
+  box-shadow: 0 12px 30px rgba(15, 29, 70, 0.12);
+}
+
+.carousel-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.carousel-control {
+  background: #0b1e51;
+  color: #ffffff;
+  border: none;
+  border-radius: 50%;
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.carousel-control:hover {
+  background: #14327a;
+  transform: translateY(-2px);
+}
+
+.carousel-dots {
+  display: flex;
+  gap: 0.5rem;
   justify-content: center;
-  margin: 2rem 0;
+  margin-top: 0.5rem;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #c5cbd6;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.dot.active {
+  background: #0b1e51;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.team-section {
+  text-align: center;
+  padding: 0 clamp(1.5rem, 6vw, 6rem);
+}
+
+.team-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 2.5rem;
+}
+
+.team-header h2 {
+  font-size: clamp(2rem, 1.8vw + 1.5rem, 2.8rem);
+}
+
+.team-header p {
+  max-width: 760px;
+  color: #3f3f3f;
+  line-height: 1.7;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  margin-bottom: 2rem;
+}
+
+.team-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 29, 70, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 1rem;
 }
-.carousel img {
-  width: 300px;
-  height: 200px;
-  object-fit: cover;
-  border-radius: 8px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.15);
-}
-.carousel button {
-  background: #2c3e50;
-  color: white;
-  border: none;
-  font-size: 2rem;
+
+.team-avatar {
+  width: 140px;
+  height: 140px;
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  overflow: hidden;
+  background: #f2d37a;
+  display: grid;
+  place-items: center;
+}
+
+.team-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.team-card h3,
+.team-card h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.team-role {
+  margin: 0;
+  color: #b02a2a;
+  font-weight: 600;
+}
+
+.team-button {
+  background: linear-gradient(120deg, #b02a2a, #d94848);
+  color: #ffffff;
+  border: none;
+  padding: 0.95rem 2.5rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
   cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.team-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(176, 42, 42, 0.35);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(9, 17, 40, 0.7);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.modal-panel {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  max-width: 960px;
+  width: min(100%, 960px);
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header,
+.modal-footer {
+  padding: 1.5rem 2rem;
+  background: #f7f7fa;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.modal-content {
+  padding: 2rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.modal-content p {
+  margin: 0;
+  color: #3f3f3f;
+  text-align: center;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 1024px) {
+  .hero-section {
+    min-height: 480px;
+  }
+
+  .levels-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .carousel-control {
+    width: 44px;
+    height: 44px;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-overlay {
+    top: 8%;
+    padding: 1.25rem 1.5rem;
+  }
+
+  .hero-subcopy {
+    font-size: 1rem;
+  }
+
+  .levels-grid {
+    padding-inline: clamp(1rem, 3vw, 2rem);
+  }
+
+  .pillar {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .team-card {
+    padding: 1.75rem 1.25rem;
+  }
+
+  .modal-panel {
+    border-radius: 1.25rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero-section {
+    min-height: 520px;
+  }
+
+  .hero-overlay {
+    top: 6%;
+  }
+
+  .levels-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .carousel {
+    flex-direction: column;
+  }
+
+  .carousel-control {
+    order: 3;
+  }
+
+  .carousel-window {
+    width: 100%;
+  }
+
+  .carousel-track {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .offer-pillars,
+  .team-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .levels-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-overlay {
+    padding-inline: 1rem;
+  }
+
+  .carousel-track {
+    grid-template-columns: 1fr;
+  }
+
+  .pillar-icon {
+    width: 72px;
+    height: 72px;
+    font-size: 1.6rem;
+  }
+
+  .team-avatar {
+    width: 120px;
+    height: 120px;
+  }
 }
 </style>

--- a/src/views/Nosotros.vue
+++ b/src/views/Nosotros.vue
@@ -1,9 +1,197 @@
 <template>
-  <section>
-    <h2>Nosotros</h2>
-    <p>
-      Somos una institución dedicada a la formación integral de nuestros estudiantes, promoviendo valores y excelencia académica.
-    </p>
-    <img src="https://images.unsplash.com/photo-1464983953574-0892a716854b?auto=format&fit=crop&w=600&q=80" alt="Equipo docente" style="width:100%;max-width:400px;" />
-  </section>
+  <div class="nosotros-page">
+    <section class="hero">
+      <div class="hero__text">
+        <h1>Nosotros</h1>
+        <p>
+          El Colegio Maranatha fue fundado en 1991 por el Apostol Alfredo Ferrara
+          iniciando con preescolar y primaria. Con el tiempo, este colegio creció
+          incorporando la secundaria, preparatoria y universidad. El Colegio
+          Maranatha se distingue como un colegio cristiano evangélico acreditado con
+          principios bíblicos y que contribuye a formar el carácter, teniendo como
+          modelo a Cristo.
+        </p>
+      </div>
+      <div class="hero__image">
+        <img
+          src="https://images.unsplash.com/photo-1596492784531-6e6eb5ea9991?auto=format&fit=crop&w=900&q=80"
+          alt="Ceremonia académica del Colegio Maranatha"
+        />
+      </div>
+    </section>
+
+    <section class="feature feature--mission">
+      <div class="feature__content">
+        <div class="feature__text">
+          <h2>Nuestra Misión</h2>
+          <p>
+            Formar hombres y mujeres quienes usen su liderazgo generacional para
+            impactar positivamente a su comunidad, siendo luz y dando gloria a Dios.
+          </p>
+        </div>
+        <div class="feature__image">
+          <img
+            src="https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=900&q=80"
+            alt="Estudiantes celebrando su graduación"
+          />
+        </div>
+      </div>
+    </section>
+
+    <section class="feature feature--vision">
+      <div class="feature__content">
+        <div class="feature__image">
+          <img
+            src="https://images.unsplash.com/photo-1516534775068-ba3e7458af70?auto=format&fit=crop&w=900&q=80"
+            alt="Niños del Colegio Maranatha"
+          />
+        </div>
+        <div class="feature__text">
+          <h2>Nuestra Visión</h2>
+          <p>
+            Anclar la fe, la virtud y el crecimiento académico en generaciones
+            futuras, promoviendo el servicio al Señor y a su prójimo.
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
 </template>
+
+<style scoped>
+.nosotros-page {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  padding: 4rem clamp(1.5rem, 3vw, 4rem);
+  background: linear-gradient(90deg, #1f2b6c 0%, #27368f 100%);
+  border-radius: 24px;
+  color: #ffffff;
+  overflow: hidden;
+}
+
+.hero__text h1 {
+  font-size: clamp(2.25rem, 3vw + 1rem, 3.5rem);
+  margin-bottom: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.hero__text p {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-width: 56ch;
+}
+
+.hero__image {
+  justify-self: center;
+  max-width: 520px;
+  width: 100%;
+}
+
+.hero__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 20px;
+  box-shadow: 0 25px 45px rgba(11, 21, 65, 0.35);
+}
+
+.feature {
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.feature__content {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.feature__text {
+  padding: clamp(2.5rem, 3vw + 1rem, 4rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.feature__text h2 {
+  font-size: clamp(1.8rem, 2vw + 1rem, 2.5rem);
+  font-weight: 700;
+}
+
+.feature__text p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  max-width: 48ch;
+}
+
+.feature__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.feature--mission {
+  background-color: #c76d2c;
+  color: #fff7ec;
+}
+
+.feature--vision {
+  background-color: #f3d57c;
+  color: #3d2d12;
+}
+
+.feature--vision .feature__text h2 {
+  color: #2f1f05;
+}
+
+.feature--vision .feature__text p {
+  color: #3d2d12;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero__text p {
+    margin: 0 auto;
+  }
+
+  .feature__content {
+    grid-template-columns: 1fr;
+  }
+
+  .feature--vision .feature__content {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
+  .feature__image {
+    max-height: 320px;
+  }
+}
+
+@media (max-width: 640px) {
+  .nosotros-page {
+    gap: 2rem;
+  }
+
+  .hero {
+    padding: 3rem 1.5rem;
+  }
+
+  .feature__text {
+    padding: 2.5rem 1.5rem;
+  }
+}
+</style>

--- a/src/views/OfertaEducativa.vue
+++ b/src/views/OfertaEducativa.vue
@@ -1,12 +1,189 @@
 <template>
-  <section>
-    <h2>Oferta Educativa</h2>
-    <ul>
-      <li>Educación Primaria de 1° a 6° grado</li>
-      <li>Clases de inglés</li>
-      <li>Actividades deportivas y culturales</li>
-      <li>Laboratorio de computación</li>
-    </ul>
-    <img src="https://images.pexels.com/photos/256401/pexels-photo-256401.jpeg?auto=compress&w=600" alt="Clase" style="width:100%;max-width:400px;" />
+  <section class="oferta-educativa">
+    <div class="oferta-educativa__intro">
+      <h1 class="oferta-educativa__title">Oferta Educativa</h1>
+      <p class="oferta-educativa__description">
+        Buscamos constantemente que nuestros estudiantes identifiquen sus habilidades y capacidades para que las
+        descubran e interpreten de manera natural. Que sean conscientes de su potencial y saber qué está en ellos
+        comprometerse para mejorar no solo su vida, sino su entorno.
+      </p>
+    </div>
+
+    <div class="oferta-educativa__grid">
+      <article class="oferta-card">
+        <img
+          src="https://res.cloudinary.com/dkskuyfiu/image/upload/v1707620421/agsmaranatha/preescolar.webp"
+          alt="Niños en preescolar con pinturas"
+          class="oferta-card__image"
+          loading="lazy"
+        />
+        <div class="oferta-card__content">
+          <h2 class="oferta-card__title">Preescolar</h2>
+          <p class="oferta-card__text">
+            La educación preescolar comprende desde los 3 a 6 años. En esta etapa se generan grandes avances a nivel
+            físico, mental y social. Es la primera entrada a la vida escolar. Los niños necesitan aprender a trabajar
+            con más niños, reconocer los elementos que intervienen en su aprendizaje, así como evaluar la pertinencia de
+            los aprendizajes que tendrán que realizar más adelante.
+          </p>
+        </div>
+      </article>
+
+      <article class="oferta-card">
+        <img
+          src="https://res.cloudinary.com/dkskuyfiu/image/upload/v1707620421/agsmaranatha/primaria.webp"
+          alt="Alumnos de primaria en clase"
+          class="oferta-card__image"
+          loading="lazy"
+        />
+        <div class="oferta-card__content">
+          <h2 class="oferta-card__title">Primaria</h2>
+          <p class="oferta-card__text">
+            La educación primaria inicia a los 6 años, concluye a los 12 y dura seis años. En esta etapa nuestra misión
+            es reforzar el desarrollo de habilidades y competencias que permitan a nuestros estudiantes un excelente
+            desenvolvimiento social, emocional, cultural y académico. Buscamos prepararles para el nivel secundario.
+          </p>
+        </div>
+      </article>
+
+      <article class="oferta-card">
+        <img
+          src="https://res.cloudinary.com/dkskuyfiu/image/upload/v1707620421/agsmaranatha/secundaria.webp"
+          alt="Alumnos de secundaria formados"
+          class="oferta-card__image"
+          loading="lazy"
+        />
+        <div class="oferta-card__content">
+          <h2 class="oferta-card__title">Secundaria</h2>
+          <p class="oferta-card__text">
+            La educación secundaria va de los 13 a los 15 años y comprende tres grados. Aquí ayudamos a los estudiantes a
+            seguir madurando sus capacidades intelectuales y sociales, fomentando la responsabilidad y el pensamiento
+            crítico. Promovemos actividades académicas, culturales y deportivas que les preparan para los retos del nivel
+            medio superior.
+          </p>
+        </div>
+      </article>
+
+      <article class="oferta-card">
+        <img
+          src="https://res.cloudinary.com/dkskuyfiu/image/upload/v1707620421/agsmaranatha/preparatoria.webp"
+          alt="Graduados de preparatoria con birretes"
+          class="oferta-card__image"
+          loading="lazy"
+        />
+        <div class="oferta-card__content">
+          <h2 class="oferta-card__title">Preparatoria</h2>
+          <p class="oferta-card__text">
+            La educación en este periodo abarca desde los 16 a los 18 años. Se divide en tres grados y, al finalizar, los
+            alumnos obtienen un certificado y, en su momento, el título. Buscamos acompañarles en la toma de decisiones
+            para su formación profesional, tanto en ámbito académico, vocacional y en los valores que forman parte de su
+            proyecto de vida.
+          </p>
+        </div>
+      </article>
+    </div>
   </section>
 </template>
+
+<style scoped>
+.oferta-educativa {
+  padding: 4rem 1.5rem 5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.oferta-educativa__intro {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.oferta-educativa__title {
+  font-size: clamp(2.25rem, 2vw + 1.5rem, 3rem);
+  font-weight: 700;
+  margin-bottom: 1.25rem;
+  color: #1f1f1f;
+}
+
+.oferta-educativa__description {
+  font-size: clamp(1rem, 0.7vw + 0.95rem, 1.125rem);
+  line-height: 1.8;
+  color: #4a4a4a;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.oferta-educativa__grid {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.oferta-card {
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 25px 45px rgba(31, 31, 31, 0.08);
+  overflow: hidden;
+  display: grid;
+  gap: 0;
+  grid-template-columns: 1fr;
+}
+
+.oferta-card__image {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.oferta-card__content {
+  padding: 2rem;
+}
+
+.oferta-card__title {
+  font-size: clamp(1.5rem, 0.8vw + 1.3rem, 1.75rem);
+  color: #1f1f1f;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.oferta-card__text {
+  font-size: clamp(0.975rem, 0.4vw + 0.85rem, 1.075rem);
+  line-height: 1.75;
+  color: #4a4a4a;
+  margin: 0;
+}
+
+@media (min-width: 768px) {
+  .oferta-educativa {
+    padding: 5rem 2.5rem 6rem;
+  }
+
+  .oferta-educativa__grid {
+    gap: 3rem;
+  }
+
+  .oferta-card {
+    grid-template-columns: 1fr 1fr;
+    align-items: stretch;
+  }
+
+  .oferta-card:nth-child(even) .oferta-card__image {
+    order: 2;
+  }
+
+  .oferta-card:nth-child(even) .oferta-card__content {
+    order: 1;
+  }
+
+  .oferta-card__image {
+    height: 100%;
+  }
+}
+
+@media (min-width: 1024px) {
+  .oferta-educativa__grid {
+    gap: 3.5rem;
+  }
+
+  .oferta-card__content {
+    padding: 2.5rem 3rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- rebuild the Home view with a hero welcome banner and level cards that reveal age-focused descriptions on hover
- add the Oferta Educativa highlight section with supporting pillar icons and a responsive three-up gallery carousel
- introduce the Conoce a nuestro personal section with leadership cards and a modal that reveals the full teaching team roster

## Testing
- not run (npm test script not available)


------
https://chatgpt.com/codex/tasks/task_e_68df3fb42ca0832bb31609146f0475d4