### PR TITLE
Add npm legacy peer dependency configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # agsMaranatha
 Nuevo dominio del colegio Maranatha Aguascalientes
 
+## Development setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+> [!NOTE]
+> This repository includes an `.npmrc` file that enables `legacy-peer-deps`. The setting suppresses peer dependency resolution
+> conflicts between Vite 7 and `@vitejs/plugin-vue` so the install step can complete without manual flags.
+
 ## Public Font Library Recommendation
 
 To complement the refreshed header design, consider using **Google Fonts**, a free and widely trusted font library. It offers an extensive catalog of open-licensed typefaces, easy CDN integration, and performance-focused loading options (such as `display=swap`). Visit [fonts.google.com](https://fonts.google.com) to browse families, generate `<link>` tags, or download font files for self-hosting.


### PR DESCRIPTION
## Summary
- add an .npmrc that enables legacy peer dependency resolution so npm install succeeds with Vite 7
- document the setup steps and the new configuration note in the README

## Testing
- npm install *(fails in CI due to restricted network access; requires internet to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e01edabdb8832b931798b14749dc01