### PR TITLE
Inline home and contact icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2Pk6dp9JdR2LrjHkG4BfXoJ1cQW+X4V9Z4O0j3x0WkNsMZ8zKeqf3r9F0w=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
     <title>Colegio Maranatha Aguascalientes</title>
   </head>
   <body>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -20,11 +20,25 @@
         <h2 id="footer-contact" class="footer__heading">Contacto</h2>
         <ul class="footer__list">
           <li class="footer__item">
-            <i class="fa-solid fa-phone"></i>
+            <span class="footer__icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" role="img" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M2.25 3C2.25 2.172 2.922 1.5 3.75 1.5h2.25c.621 0 1.125.504 1.125 1.125V4.5c0 .621-.504 1.125-1.125 1.125H5.25a8.25 8.25 0 0 0 5.625 5.625h1.875c.621 0 1.125.504 1.125 1.125v2.25c0 .828-.672 1.5-1.5 1.5h-.75A11.25 11.25 0 0 1 2.25 3Z"
+                />
+              </svg>
+            </span>
             <a href="tel:4491466009">449 146 6009</a>
           </li>
           <li class="footer__item">
-            <i class="fa-solid fa-envelope"></i>
+            <span class="footer__icon" aria-hidden="true">
+              <svg viewBox="0 0 20 20" role="img" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M3.75 4.5h12.5A1.75 1.75 0 0 1 18 6.25v7.5A1.75 1.75 0 0 1 16.25 15.5H3.75A1.75 1.75 0 0 1 2 13.75v-7.5A1.75 1.75 0 0 1 3.75 4.5Zm0 1.5a.25.25 0 0 0-.25.25v.142l6.186 4.34a.75.75 0 0 0 .828 0L16.75 6.392V6.25a.25.25 0 0 0-.25-.25H3.75Zm12.5 8.25a.25.25 0 0 0 .25-.25V8.322l-5.53 3.881a2.25 2.25 0 0 1-2.44 0L3 8.322V14a.25.25 0 0 0 .25.25h12.5Z"
+                />
+              </svg>
+            </span>
             <a href="mailto:colegiomaranathaags@hotmail.com">colegiomaranathaags@hotmail.com</a>
           </li>
         </ul>
@@ -40,7 +54,14 @@
             rel="noopener noreferrer"
             aria-label="Facebook"
           >
-            <i class="fa-brands fa-facebook-f"></i>
+            <span class="footer__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M15 3h2.25A.75.75 0 0 1 18 3.75v2.5a.75.75 0 0 1-.75.75H15v2.5h2.25a.75.75 0 0 1 .74.92l-.5 2.5a.75.75 0 0 1-.74.58H15V21.5a.75.75 0 0 1-.75.75h-3a.75.75 0 0 1-.75-.75V13.5H8.25a.75.75 0 0 1-.75-.75v-2.5A.75.75 0 0 1 8.25 9.5H10.5V7a4 4 0 0 1 4-4Z"
+                />
+              </svg>
+            </span>
           </a>
           <a
             class="footer__social-link"
@@ -49,7 +70,14 @@
             rel="noopener noreferrer"
             aria-label="Instagram"
           >
-            <i class="fa-brands fa-instagram"></i>
+            <span class="footer__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M7 3h10a4 4 0 0 1 4 4v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4Zm0 2a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7Zm5 3.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Zm0 2a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Zm5.25-.75a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5Z"
+                />
+              </svg>
+            </span>
           </a>
           <a
             class="footer__social-link"
@@ -58,7 +86,14 @@
             rel="noopener noreferrer"
             aria-label="YouTube"
           >
-            <i class="fa-brands fa-youtube"></i>
+            <span class="footer__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M4.75 6A2.75 2.75 0 0 0 2 8.75v6.5A2.75 2.75 0 0 0 4.75 18h14.5A2.75 2.75 0 0 0 22 15.25v-6.5A2.75 2.75 0 0 0 19.25 6H4.75Zm6.83 3.42 3.75 2.25a.75.75 0 0 1 0 1.26l-3.75 2.25a.75.75 0 0 1-1.14-.63v-4.5a.75.75 0 0 1 1.14-.63Z"
+                />
+              </svg>
+            </span>
           </a>
         </div>
       </section>
@@ -144,9 +179,18 @@ export default {
   font-size: clamp(0.95rem, 2vw, 1.05rem);
 }
 
-.footer__item i {
-  font-size: 1.1rem;
+.footer__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
   color: #ffcf4a;
+}
+
+.footer__icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .footer__item a {

--- a/src/views/Contacto.vue
+++ b/src/views/Contacto.vue
@@ -2,7 +2,20 @@
   <section class="contact-page">
     <div class="contact-card">
       <button class="contact-close" type="button" aria-label="Cerrar formulario">
-        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+        <svg
+          class="contact-close__icon"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path d="M6 6l12 12M18 6 6 18" />
+        </svg>
       </button>
       <header class="contact-header">
         <h2 class="contact-title">¿Requiere más información?</h2>
@@ -121,9 +134,12 @@ const handleSubmit = () => {
   border: none;
   background: transparent;
   color: #da1a32;
-  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
   cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease;
+  display: grid;
+  place-items: center;
+  width: clamp(2.25rem, 3vw, 2.75rem);
+  height: clamp(2.25rem, 3vw, 2.75rem);
 }
 
 .contact-close:focus-visible {
@@ -134,6 +150,11 @@ const handleSubmit = () => {
 .contact-close:hover {
   transform: scale(1.05);
   opacity: 0.8;
+}
+
+.contact-close__icon {
+  width: clamp(1.25rem, 2.4vw, 1.5rem);
+  height: clamp(1.25rem, 2.4vw, 1.5rem);
 }
 
 .contact-header {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -41,8 +41,22 @@
       </div>
       <div class="offer-pillars">
         <div v-for="pillar in pillars" :key="pillar.title" class="pillar">
-          <div class="pillar-icon">
-            <i :class="pillar.icon" aria-hidden="true"></i>
+          <div class="pillar-icon" aria-hidden="true">
+            <svg
+              class="pillar-icon__svg"
+              :viewBox="pillar.icon.viewBox"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              focusable="false"
+            >
+              <path
+                v-for="(path, index) in pillar.icon.paths"
+                :key="index"
+                :d="path.d"
+                :fill="path.fill ?? 'currentColor'"
+                :opacity="path.opacity"
+              />
+            </svg>
           </div>
           <h3>{{ pillar.title }}</h3>
           <p>{{ pillar.copy }}</p>
@@ -59,7 +73,20 @@
           aria-label="Anterior"
           :disabled="totalSlides === 1"
         >
-          <i class="fas fa-chevron-left" aria-hidden="true"></i>
+          <svg
+            class="carousel-icon"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M14.5 5.5 9 12l5.5 6.5" />
+          </svg>
         </button>
         <div class="carousel-window">
           <div class="carousel-track" :style="trackStyles">
@@ -79,7 +106,20 @@
           aria-label="Siguiente"
           :disabled="totalSlides === 1"
         >
-          <i class="fas fa-chevron-right" aria-hidden="true"></i>
+          <svg
+            class="carousel-icon"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="m9.5 5.5 5.5 6.5-5.5 6.5" />
+          </svg>
         </button>
       </div>
       <div class="carousel-dots" role="tablist" aria-label="Seleccionar grupo de imágenes">
@@ -130,7 +170,20 @@
           <header class="modal-header">
             <h3 id="team-modal-title">Equipo docente completo</h3>
             <button type="button" class="modal-close" @click="closeModal" aria-label="Cerrar">
-              <i class="fas fa-times" aria-hidden="true"></i>
+              <svg
+                class="modal-close__icon"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path d="M6 6l12 12M18 6 6 18" />
+              </svg>
             </button>
           </header>
           <div class="modal-content">
@@ -187,17 +240,41 @@ const pillars = [
   {
     title: 'Inspiramos creatividad',
     copy: 'Integramos arte, música y experiencias vivenciales para despertar la imaginación en cada aula.',
-    icon: 'fas fa-lightbulb'
+    icon: {
+      viewBox: '0 0 24 24',
+      paths: [
+        {
+          d: 'M12 2a7 7 0 0 0-4.3 12.6c.5.4.8 1 .8 1.6V17a2 2 0 0 0 2 2v1a1 1 0 0 0 2 0v-1a2 2 0 0 0 2-2v-.8c0-.6.3-1.2.8-1.6A7 7 0 0 0 12 2Zm1 14h-2v-2h2v2Z',
+        },
+        {
+          d: 'M9 21a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-1H9v1Z',
+        },
+      ],
+    }
   },
   {
     title: 'Excelencia académica',
     copy: 'Programas actualizados y docentes certificados garantizan un aprendizaje significativo.',
-    icon: 'fas fa-graduation-cap'
+    icon: {
+      viewBox: '0 0 24 24',
+      paths: [
+        { d: 'M12 3 2 8l10 5 10-5-10-5Z' },
+        { d: 'M5 10.5v3.2c0 2 3.3 3.8 7 3.8s7-1.8 7-3.8v-3.2l-7 3.5-7-3.5Z' },
+        { d: 'M19 11v5.8a1.2 1.2 0 0 0 2.4 0V9.8L19 11Z' },
+      ],
+    }
   },
   {
     title: 'Cuidado integral',
     copy: 'Acompañamos el bienestar físico, emocional y espiritual de nuestra comunidad educativa.',
-    icon: 'fas fa-hands-holding-heart'
+    icon: {
+      viewBox: '0 0 24 24',
+      paths: [
+        { d: 'M12 6.5c-1.3-1.6-3.7-1.7-5.1-.2a3.6 3.6 0 0 0 0 4.9l5.1 5.3 5.1-5.3a3.6 3.6 0 0 0 0-4.9c-1.4-1.5-3.8-1.4-5.1.2Z' },
+        { d: 'M4.2 13.7c-.7.4-1.2 1.1-1.2 1.9v2.6c0 1.4.9 2.7 2.3 3.2l4.4 1.6c1.1.4 2.3-.4 2.3-1.6v-3.1a2.5 2.5 0 0 0-1.4-2.2l-3-1.5a2.6 2.6 0 0 0-2.4.1Z' },
+        { d: 'M19.8 13.7a2.6 2.6 0 0 0-2.4-.1l-3 1.5a2.5 2.5 0 0 0-1.4 2.2v3.1c0 1.2 1.2 2 2.3 1.6l4.4-1.6c1.4-.5 2.3-1.8 2.3-3.2v-2.6c0-.8-.5-1.5-1.2-1.9Z' },
+      ],
+    }
   }
 ]
 
@@ -639,7 +716,11 @@ onUnmounted(() => {
   display: grid;
   place-items: center;
   color: #ffffff;
-  font-size: 2rem;
+}
+
+.pillar-icon__svg {
+  width: 42px;
+  height: 42px;
 }
 
 .pillar h3 {
@@ -709,6 +790,11 @@ onUnmounted(() => {
   place-items: center;
   cursor: pointer;
   transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.carousel-icon {
+  width: 20px;
+  height: 20px;
 }
 
 .carousel-control:not(:disabled):hover {
@@ -879,9 +965,17 @@ onUnmounted(() => {
 .modal-close {
   background: transparent;
   border: none;
-  font-size: 1.5rem;
   color: #1a1a1a;
   cursor: pointer;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+}
+
+.modal-close__icon {
+  width: 24px;
+  height: 24px;
 }
 
 .modal-content {
@@ -1009,7 +1103,11 @@ onUnmounted(() => {
   .pillar-icon {
     width: 72px;
     height: 72px;
-    font-size: 1.6rem;
+  }
+
+  .pillar-icon__svg {
+    width: 36px;
+    height: 36px;
   }
 
   .team-avatar {


### PR DESCRIPTION
## Summary
- replace the home page Font Awesome icon tags with inline SVGs, including new pillar icon data and supporting styles
- render the contact form close button with inline SVG and center the control for consistent sizing

## Testing
- `npm run build` *(fails: vite executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e034cc4230832b8e3c705dc56cc98e